### PR TITLE
Fix Syntax Errors When Pip Installing on Python 3 and Add Classifiers for Python 3 Support

### DIFF
--- a/dateutils/dateadd.py
+++ b/dateutils/dateadd.py
@@ -2,6 +2,7 @@ from . import TIME_UNITS, date_range, increment
 from dateutil.parser import parse
 from datetime import datetime
 from argparse import ArgumentParser
+from future import print_function
 
 
 def get_arguments():
@@ -53,4 +54,4 @@ def main():
         if any(bool(v) for v in kwargs.values()):
             dates = [increment(dt, **kwargs) for dt in dates]
     for dt in dates:
-        print dt.strftime(args.format)
+        print(dt.strftime(args.format))

--- a/dateutils/datediff.py
+++ b/dateutils/datediff.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from dateutil.parser import parse
 from argparse import ArgumentParser
+from future import print_function
 
 
 def get_arguments():
@@ -37,4 +38,4 @@ def main():
         if args.holiday_file:
             holidays.extend(parse(l) for l in open(args.holiday_file))
         kwargs['holidays'] = holidays
-    print __import__(args.unit)(end_dt, start_dt, **kwargs)
+    print(__import__(args.unit)(end_dt, start_dt, **kwargs))

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
             'Natural Language :: English',
             'Operating System :: POSIX :: Linux',
             'Programming Language :: Python',
+            'Programming Language :: Python :: 3',
             ],
         install_requires=[
             'argparse',


### PR DESCRIPTION
Hi, the fixes to the print functions should work on versions >= Python 2.6. If you want to support older versions than that then let me know and I will try to fix the changes.

When you merge this could you please upload a new release with the changes to PyPI so the version there will show up as supporting Python 3 and install without errors on that version.

Thanks.
