### PR TITLE
Fix build with Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from io import open
 from os import path
 from setuptools import setup
 


### PR DESCRIPTION
The error message is as follows:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "setup.py", line 7, in <module>
    with open(path.join(this_directory, 'README.mkd'), encoding='utf-8') as f:
TypeError: 'encoding' is an invalid keyword argument for this function
*** Error code 1

Stop.