### PR TITLE
Only require argparse when needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
 
     install_requires=[
-        'argparse',
+        'argparse; python_version < "2.7"',
         'python-dateutil',
         'pytz'
     ],


### PR DESCRIPTION
`argparse` is available in the stdlib in all non-ancient Python versions (2.7+), and installing it is pointless because the stdlib copy always takes precedence. The name conflict, however, causes problems in some edge case.

This patch adds an [environment marker](https://www.python.org/dev/peps/pep-0508/#environment-markers) so the library is only pulled in when `argparse` is not present.